### PR TITLE
Make it work with Astro 3

### DIFF
--- a/packages/md/lib/component.js
+++ b/packages/md/lib/component.js
@@ -1,4 +1,4 @@
-import { renderSlot } from 'astro/server/render/index.js'
+import { renderSlot } from 'astro/runtime/server/index.js'
 import { markdown } from './markdown.js'
 
 export const Markdown = Object.assign(

--- a/packages/md/package.json
+++ b/packages/md/package.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "@astropub/md",
 	"description": "Render any Markdown content in Astro",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"type": "module",
 	"license": "CC0-1.0",
 	"exports": {
@@ -25,7 +25,7 @@
 		"./package.json": "./package.json"
 	},
 	"peerDependencies": {
-		"@astrojs/markdown-remark": "^1 || ^2"
+		"@astrojs/markdown-remark": "^3"
 	},
 	"main": "astro-md.js",
 	"types": "astro-md.d.ts",


### PR DESCRIPTION
See https://github.com/astro-community/md/issues/7

It seems that the URL for the `renderSlot` export changes in Astro 3, so I did update it here, and also changed the peer dependency for `@astrojs/markdown-remark` to only be 3, as I'm not sure of a good way to handle two different paths for `renderSlot`, and I'm not sure it is a good overall idea to support older version in this case.

Tested locally, and it seems to work fine for me.