### PR TITLE
Support Astro 4

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
 		"astro": "astro"
 	},
 	"devDependencies": {
-		"@astropub/md": "0.2.0",
+		"@astropub/md": "file:../packages/md",
 		"astro": "latest"
 	}
 }

--- a/packages/md/lib/markdown.js
+++ b/packages/md/lib/markdown.js
@@ -1,34 +1,37 @@
-import { renderMarkdown } from '@astrojs/markdown-remark'
-import { shared } from './shared.js'
-import { HTMLString } from './html-string.js'
+import { createMarkdownProcessor } from "@astrojs/markdown-remark";
+import { shared } from "./shared.js";
+import { HTMLString } from "./html-string.js";
 
 export async function markdown(
 	/** @type {string} */ content,
-	/** @type {MarkdownRenderingOptions} */ options = null
+	/** @type {MarkdownRenderingOptions} */ options = null,
 ) {
-	return await renderMarkdown(content, {
+	const processor = await createMarkdownProcessor({
 		...shared.markdownConfig,
 		...Object(options),
-	}).then(
-		result => new HTMLString(result.code)
-	)
+	});
+
+	const result = await processor.render(content);
+	return new HTMLString(result.code);
 }
 
 markdown.inline = async function inlinemarkdown(
 	/** @type {string} */ content,
-	/** @type {MarkdownRenderingOptions} */ options = null
+	/** @type {MarkdownRenderingOptions} */ options = null,
 ) {
-	return await renderMarkdown(content, {
+	const processor = await createMarkdownProcessor({
 		...shared.markdownConfig,
 		...Object(options),
-	}).then(
-		result => new HTMLString(
-			result.code.indexOf('<p>') === 0 &&
-			result.code.indexOf('</p>') === result.code.length - 4
-				? result.code.slice(3, -4)
-			: result.code
-		)
-	)
-}
+	});
+
+	const result = await processor.render(content);
+
+	return new HTMLString(
+		result.code.indexOf("<p>") === 0 &&
+		result.code.indexOf("</p>") === result.code.length - 4
+			? result.code.slice(3, -4)
+			: result.code,
+	);
+};
 
 /** @typedef {import('./markdown').MarkdownRenderingOptions} MarkdownRenderingOptions */

--- a/packages/md/lib/markdown.js
+++ b/packages/md/lib/markdown.js
@@ -1,10 +1,10 @@
-import { createMarkdownProcessor } from "@astrojs/markdown-remark";
-import { shared } from "./shared.js";
-import { HTMLString } from "./html-string.js";
+import { createMarkdownProcessor } from '@astrojs/markdown-remark'
+import { shared } from './shared.js'
+import { HTMLString } from './html-string.js'
 
 export async function markdown(
 	/** @type {string} */ content,
-	/** @type {MarkdownRenderingOptions} */ options = null,
+	/** @type {MarkdownRenderingOptions} */ options = null
 ) {
 	const processor = await createMarkdownProcessor({
 		...shared.markdownConfig,
@@ -17,7 +17,7 @@ export async function markdown(
 
 markdown.inline = async function inlinemarkdown(
 	/** @type {string} */ content,
-	/** @type {MarkdownRenderingOptions} */ options = null,
+	/** @type {MarkdownRenderingOptions} */ options = null
 ) {
 	const processor = await createMarkdownProcessor({
 		...shared.markdownConfig,

--- a/packages/md/package.json
+++ b/packages/md/package.json
@@ -25,7 +25,7 @@
 		"./package.json": "./package.json"
 	},
 	"peerDependencies": {
-		"@astrojs/markdown-remark": "^3"
+		"@astrojs/markdown-remark": "^4"
 	},
 	"main": "astro-md.js",
 	"types": "astro-md.d.ts",


### PR DESCRIPTION
v4 of `@astrojs/markdown-remark` used by Astro v4 uses a different interface for creating the markdown processor and rendering the markdown. This PR updates the `md` plugin to make sure it can support it.

Open question: this is a breaking change with no backwards compatibility in mind, I'm open to incorporate suggestions in this PR on how that should be best handled.
