### PR TITLE
fix: user lower-case string for markdown and inline

### DIFF
--- a/packages/md/lib/markdown.d.ts
+++ b/packages/md/lib/markdown.d.ts
@@ -6,10 +6,10 @@ export var markdown: {
 	(
 		content: string,
 		options?: MarkdownRenderingOptions
-	): Promise<String>
+	): Promise<string>
 
 	inline(
 		content: string,
 		options?: MarkdownRenderingOptions
-	): Promise<String>
+	): Promise<string>
 }


### PR DESCRIPTION
Fixes #9.